### PR TITLE
Initiatize plugin variable to fix TypeError

### DIFF
--- a/assembla2github.coffee
+++ b/assembla2github.coffee
@@ -34,6 +34,7 @@ collections = {}
 fieldsMeta = {}
 
 # Require transform plugin if needed
+plugin = {transform:""};
 plugin = require(argv.transform) if argv.transform
 
 ###


### PR DESCRIPTION
Fix this error:
TypeError: Cannot read property 'transform' of undefined
By initializing plugin.