### PR TITLE
Fix state (open/closed) of imported issues on GitHub

### DIFF
--- a/assembla2github.coffee
+++ b/assembla2github.coffee
@@ -465,11 +465,13 @@ exportToGithub = ->
               body: issue.body
               assignee: issue.assignee
               labels: issue.labels || []
-              state: issue.state
             )
             .spread (body, headers) ->
-              # Save Assembla Id and Github Id mapping to MongoDb
               githubId = parseInt(body.number)
+              # Update state information (open, closed)
+              githubIssue = github.issue(argv.repo.path, githubId)
+              githubIssue.updateAsync(state: issue.state)
+              # Save Assembla Id and Github Id mapping to MongoDb
               db.collection('assembla2github').updateAsync({'assembla_ticket_number': issue.number},
                 {
                   'assembla_ticket_number': issue.number

--- a/assembla2github.coffee
+++ b/assembla2github.coffee
@@ -206,7 +206,7 @@ joinValues = (ticket) ->
     .find({'id': ticket.ticket_status_id}).toArrayAsync()
     .then (data) ->
       if data.length > 0
-        return data[0].title
+        return data[0].name
 
   # Append Tags
   tags = db.collection('ticket_tags')


### PR DESCRIPTION
Apparently, the GitHub API V3 does not allow setting the state directly at creation, so it has to be updated after the fact.