### PR TITLE
Add a feature to import your comment history

### DIFF
--- a/assembla2github.coffee
+++ b/assembla2github.coffee
@@ -467,6 +467,9 @@ exportToGithub = ->
                     issue.body += "\n\n>__&lt;Comments migrated from Assembla&gt;__"
                     flagFirstComment = false
                   newComment = comment.comment
+                  # Replace Assembla ticket references 're: #85' to 'AS-85'
+                  re = /#(\d+)/g
+                  newComment = newComment.replace(re, "AS-$1")
                   # Replace commit reference '[[r:47|repo:47]]' by 'r47'
                   re = /\[\[r:(\d+)\|[^\]]*\]\]/g
                   newComment = newComment.replace(re, "r$1")

--- a/assembla2github.coffee
+++ b/assembla2github.coffee
@@ -467,6 +467,9 @@ exportToGithub = ->
                     issue.body += "\n\n>__&lt;Comments migrated from Assembla&gt;__"
                     flagFirstComment = false
                   newComment = comment.comment
+                  # Replace commit reference '[[r:47|repo:47]]' by 'r47'
+                  re = /\[\[r:(\d+)\|[^\]]*\]\]/g
+                  newComment = newComment.replace(re, "r$1")
                   # Append comment
                   issue.body += "\n\n> By #{comment.user_id} on #{date.toUTCString()}"
                   issue.body += "\n"+newComment

--- a/assembla2github.coffee
+++ b/assembla2github.coffee
@@ -470,6 +470,9 @@ exportToGithub = ->
                   # Replace commit reference '[[r:47|repo:47]]' by 'r47'
                   re = /\[\[r:(\d+)\|[^\]]*\]\]/g
                   newComment = newComment.replace(re, "r$1")
+                  # Add blockquote marker '>' to beginning of each line
+                  re = /([\n\r]{2,})/g
+                  newComment = newComment.replace(re, "$1> ")
                   # Append comment
                   issue.body += "\n\n> By #{comment.user_id} on #{date.toUTCString()}"
                   issue.body += "\n"+newComment

--- a/assembla2github.coffee
+++ b/assembla2github.coffee
@@ -454,6 +454,25 @@ exportToGithub = ->
       joinValues(ticket)
         .then (issue) ->
           issue = plugin.transform(issue) if _.isFunction(plugin.transform)
+          # Append ticket comments to body
+          if argv.comments
+            flagFirstComment = true
+            comments = db.collection('ticket_comments')
+              .find({'ticket_id': issue.id}).sort({id: 1}).toArrayAsync()
+              .each (comment) ->
+                if comment.comment
+                  date = new Date(comment.created_on);
+                  if flagFirstComment
+                    # Append comments header
+                    issue.body += "\n\n>__&lt;Comments migrated from Assembla&gt;__"
+                    flagFirstComment = false
+                  newComment = comment.comment
+                  # Append comment
+                  issue.body += "\n\n> By #{comment.user_id} on #{date.toUTCString()}"
+                  issue.body += "\n"+newComment
+                  if argv.verbose
+                    console.log('New body:')
+                    console.log(issue.body)
           unless _.isObject(issue)
             console.log('skipping, no data object')
             return

--- a/assembla2github.coffee
+++ b/assembla2github.coffee
@@ -481,7 +481,9 @@ exportToGithub = ->
                   issue.body += "\n"+newComment
                   if argv.verbose
                     console.log('New body:')
-                    console.log(issue.body)
+                    str = JSON.stringify(String(issue.body));
+                    str = str.substring(1, str.length-1);
+                    console.log(str)
           unless _.isObject(issue)
             console.log('skipping, no data object')
             return

--- a/assembla2github.coffee
+++ b/assembla2github.coffee
@@ -479,11 +479,6 @@ exportToGithub = ->
                   # Append comment
                   issue.body += "\n\n> By #{comment.user_id} on #{date.toUTCString()}"
                   issue.body += "\n"+newComment
-                  if argv.verbose
-                    console.log('New body:')
-                    str = JSON.stringify(String(issue.body));
-                    str = str.substring(1, str.length-1);
-                    console.log(str)
           unless _.isObject(issue)
             console.log('skipping, no data object')
             return

--- a/yargs-config.coffee
+++ b/yargs-config.coffee
@@ -61,6 +61,8 @@ module.exports = require('yargs')
       .default('delay', 250)
       .describe('github-token', 'GitHub API access token')
       .alias('t', 'github-token')
+      .describe('comments', 'Append Assembla comments to Github body')
+      .alias('c', 'comments')
       .check((argv) ->
         repoParts = argv.repo.split('/')
         throw new Error('Check GitHub repo value') unless repoParts.length is 2


### PR DESCRIPTION
In my case, there often was more information in comments on an Assembla ticket than there was in the original ticket body. I wanted this information to be available on GitHub for easy lookup and completeness, not having to follow the link to the original Assembla ticket.