### PR TITLE
Fix progress bar of exportToGithub with long repo names

### DIFF
--- a/assembla2github.coffee
+++ b/assembla2github.coffee
@@ -433,7 +433,7 @@ Export data to GitHub
   })
 ###
 exportToGithub = ->
-  bar = new ProgressBar("Exporting data to github #{argv.repo.path} [:bar] [:percent] [:eta seconds left]", {
+  bar = new ProgressBar("Exporting data to github [:bar] [:percent] [:eta seconds left]", {
     'complete': '='
     'incomplete': ' '
     'stream': process.stdout


### PR DESCRIPTION
Remove the repository name from the progress bar so the progress bar will be
visible, even with relatively long repository names. The repository is already
mentioned at the start of the export.